### PR TITLE
fix current sensor variable shadowing

### DIFF
--- a/Firmware/Embedded/Src/Hal/ACS712CurntSnsr/hCurrent_Program.c
+++ b/Firmware/Embedded/Src/Hal/ACS712CurntSnsr/hCurrent_Program.c
@@ -138,12 +138,12 @@ void hCurrent_Calibrate(void) // Adjust zero offset at no load
     if (Calibration_Actions.Callibration_Samples_Num < RMS_Nominal_Samples_Num)
     {
 
-        float VoltageConversion = (Calibration_Actions.Previous_ADC_Avrg_Value / ADC_MAX) * Vref;
+        VoltageConversion = (Calibration_Actions.Previous_ADC_Avrg_Value / ADC_MAX) * Vref;
     }
     else
     {
 
-        float VoltageConversion = (Calibration_Actions.Current_ADC_Avrg_Value / ADC_MAX) * Vref;
+        VoltageConversion = (Calibration_Actions.Current_ADC_Avrg_Value / ADC_MAX) * Vref;
     }
 
     ACS712_ZERO_OFFSET = VoltageConversion;


### PR DESCRIPTION

<img width="745" height="480" alt="Screenshot 2026-01-25 013601" src="https://github.com/user-attachments/assets/a38db086-f655-4557-b801-b04f219d95f3" />

https://github.com/user-attachments/assets/b5545819-5d64-422e-b416-c6b702661060

something make ACS712_ZERO_OFFSET equal 0 at no load and that make the current equal nearly 37A

@Hisham4Ahmed 


