### PR TITLE
Fix/003/Active_Power_Calculation

### DIFF
--- a/Firmware/Embedded/Src/App/MeasurementEngine/MeasurementEngine_Config.h
+++ b/Firmware/Embedded/Src/App/MeasurementEngine/MeasurementEngine_Config.h
@@ -22,6 +22,32 @@
  */
 #define ME_SAMPLE_INTERVAL   0.01f   
 
+/**
+ * @def Resistive_Load_PF
+ * @brief Power Factor for Resistive Loads.
+ */
+#define Resistive_Load_PF 1.0f
+/**
+ * @def AVG_Residential_Load_PF
+ * @brief Average Power Factor for Residential Loads, Assumed to be 0.85.
+ */
+#define AVG_Residential_Load_PF 0.85f
 
+/**
+ * @def Load_Type
+ * @brief Type of load connected to the system.
+ */
+#define Load_Type AVG_Residential_Load
+
+/**
+ * @def Resistive_Load
+ * @brief Identifier for Resistive Load type.
+ */
+#define Resistive_Load 1
+/**
+ * @def AVG_Residential_Load
+ * @brief Identifier for Average Residential Load type.
+ */
+#define AVG_Residential_Load 2
 
 #endif /* MEASUREMENT_ENGINE_CONFIG_H */

--- a/Firmware/Embedded/Src/App/MeasurementEngine/MeasurementEngine_Interface.h
+++ b/Firmware/Embedded/Src/App/MeasurementEngine/MeasurementEngine_Interface.h
@@ -84,12 +84,12 @@ float ME_GetCurrentRMS(void);
 
 /*============================================================================*/
 /**
- * @fn         float ME_GetPower(void)
+ * @fn         float ME_GetActivePower(void)
  * @brief      Returns the instantaneous active power.
  * @details    Computes the active power based on voltage and current RMS values.
  * @return     float  Active power in watts (W).
  */
-float ME_GetPower(void);
+float ME_GetActivePower(void);
 
 /*============================================================================*/
 /**

--- a/Firmware/Embedded/Src/App/MeasurementEngine/MeasurementEngine_Interface.h
+++ b/Firmware/Embedded/Src/App/MeasurementEngine/MeasurementEngine_Interface.h
@@ -109,6 +109,15 @@ float ME_GetEnergy(void);
  */
 void ME_ResetEnergy(void);
 
+/*============================================================================*/
+/**
+ * @fn ME_GetApparentPower(void)
+ * @brief      Returns the instantaneous apparent power.
+ * @details    Computes the apparent power based on voltage and current RMS values.
+ * @return     float  Apparent power in volt-amperes (VA).
+ */
+
+float ME_GetApparentPower(void);
 /** @} */ /* End of MeasurementEngine group */
 
 

--- a/Firmware/Embedded/Src/App/MeasurementEngine/MeasurementEngine_Progarm.c
+++ b/Firmware/Embedded/Src/App/MeasurementEngine/MeasurementEngine_Progarm.c
@@ -30,12 +30,13 @@ static float ME_Vrms = 0.0f;
 /** @brief Latest calculated RMS Current (Amperes). */
 static float ME_Irms = 0.0f;
 
-/** @brief Latest calculated Active Power (Watts). */
-static float ME_Power = 0.0f;
+/** @brief Latest calculated Apparent Power (VA). */
+static float ME_Apparent_Power = 0.0f;
 
 /** @brief Accumulated Energy (Joules/Watt-seconds). */
 static float ME_Energy = 0.0f;
-
+/** @brief Latest calculated Active Power (Watts). */
+static float ME_Active_Power = 0.0f;
 /*============================================================================
  *                                 Function Definitions
  *============================================================================*/
@@ -66,10 +67,14 @@ void ME_Update(void)
     ME_Vrms = hVoltage_ReadRMS();
     ME_Irms = hCurrent_ReadRMS();
 
-    ME_Power = ME_Vrms * ME_Irms;
-
+    ME_Apparent_Power = ME_Vrms * ME_Irms;
+#if Load_Type == Resistive_Load
+    ME_Active_Power = ME_Apparent_Power * Resistive_Load_PF;
+#elif Load_Type == AVG_Residential_Load
+    ME_Active_Power = ME_Apparent_Power * AVG_Residential_Load_PF ;
+#endif
     /* Energy accumulation: Energy (J) = Power (W) * Time (s) */
-    ME_Energy += ME_Power * ME_SAMPLE_INTERVAL;
+    ME_Energy += ME_Active_Power * ME_SAMPLE_INTERVAL;
 }
 
 /**
@@ -96,7 +101,7 @@ float ME_GetCurrentRMS(void)
  */
 float ME_GetPower(void)      
 { 
-    return ME_Power; 
+    return ME_Active_Power; 
 }
 
 /**
@@ -116,4 +121,9 @@ float ME_GetEnergy(void)
 void ME_ResetEnergy(void)
 {
     ME_Energy = 0.0f;
+}
+
+float ME_GetApparentPower(void)
+{
+    return ME_Apparent_Power;
 }

--- a/Firmware/Embedded/Src/App/MeasurementEngine/MeasurementEngine_Progarm.c
+++ b/Firmware/Embedded/Src/App/MeasurementEngine/MeasurementEngine_Progarm.c
@@ -99,7 +99,7 @@ float ME_GetCurrentRMS(void)
  * @brief      Getter for the calculated Active Power.
  * @return     float Power in Watts (W).
  */
-float ME_GetPower(void)      
+float ME_GetActivePower(void)      
 { 
     return ME_Active_Power; 
 }


### PR DESCRIPTION
[Calculated the Active Power Instead of Apparent Power Support Different Load Types (Resistive and Average Residential Load)] [Fix]#003 Fix Power Factor Calculation Based on Load Type

![WhatsApp Image 2026-01-25 at 2 51 09 PM](https://github.com/user-attachments/assets/8ad3891c-9295-4fbf-a76e-1e59bcc4c49d)

using assumed residential PF =0.85

@Hisham4Ahmed 