### PR TITLE
Add auto-connect to last paired Bluetooth device in EnergyProvider

### DIFF
--- a/Firmware/Mobile/Src/mobile_app/lib/providers/energy_provider.dart
+++ b/Firmware/Mobile/Src/mobile_app/lib/providers/energy_provider.dart
@@ -68,6 +68,20 @@ class EnergyProvider with ChangeNotifier {
     // Load paired device
     _connectedDevice = _storageService.getPairedDevice();
 
+    if (_connectedDevice != null) {
+      try {
+        final success =
+            await _bluetoothService.connect(_connectedDevice!.address);
+        if (success) {
+          _connectedDevice =
+              _connectedDevice!.copyWith(isConnected: true);
+          _isConnected = true;
+        }
+      } catch (e) {
+        _connectionError = 'Auto-connect failed: $e';
+      }
+    }
+
     // Subscribe to streams
     _dataSubscription =
         _bluetoothService.dataStream.listen(_handleIncomingData);


### PR DESCRIPTION
### Motivation
- Ensure the app updates its internal connection state when a device has been paired/connected at the system level by attempting to connect to the last paired device during provider initialization.
- Surface a clear error message when the auto-connect attempt fails so the UI can report connection issues.

### Description
- In `EnergyProvider._initialize()` load the saved paired device via `_storageService.getPairedDevice()` and attempt to connect with `_bluetoothService.connect(<address>)` if present.
- On successful connect update `_connectedDevice` using `copyWith(isConnected: true)` and set `_isConnected = true`.
- Catch exceptions from the connect attempt and set `_connectionError` to a descriptive message (`'Auto-connect failed: $e'`).
- Preserve existing stream subscriptions and `notifyListeners()` flow after the auto-connect logic.

### Testing
- No automated tests were run for this change (`not run`).
- No test failures reported because no test suite was executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b48bf6c2c83278c8c1c81fc4f1afd)